### PR TITLE
Adapt to updated jwt authentication

### DIFF
--- a/server/routes/authentication.ts
+++ b/server/routes/authentication.ts
@@ -5,7 +5,7 @@ import express = require('express');
 import eJwt = require('express-jwt');
 import jwt = require('jsonwebtoken');
 import {IUserModel, User} from '../models/user.model'
-import {IUser} from '../entities/user.interface';
+import {UserType} from '../entities/user-type';
 
 export let authenticationRoute = express.Router();
 
@@ -27,7 +27,7 @@ authenticationRoute.post('/api/authenticate', function (req: express.Request, re
         let authToken = jwt.sign({
           id: user.id,
           username: user.username,
-          userType: user.type
+          type: user.type
         }, "secret", {expiresIn: "1h"});
         logger.info(`user ${user.username} authenticated successfully`);
         res.json({
@@ -45,11 +45,16 @@ authenticationRoute.post('/api/authenticate', function (req: express.Request, re
 // TODO: das Passwort 'secret' muss noch ersetzt werden. Am besten mit einem privaten und einem öffentlichen Schlüssel.
 authenticationRoute.use('/api', eJwt({secret: 'secret'}), function (req: express.Request & jwtTypeExtension.Authenticated<IUserModel>, res: express.Response, next: express.NextFunction) {
   if (req.user) {
-    logger.info(`userid: ${req.user.id}, username: ${req.user.username}, req.body: ` + JSON.stringify(req.body));
+    logger.info(`userid: ${req.user.id}, username: ${req.user.username}, type: ${req.user.type}, req.body: ` + JSON.stringify(req.body));
     next();
   } else {
     res.status(401).json({error: 'not yet authenticated'});
   }
+});
+
+// Used for REST test
+authenticationRoute.get('/api/authenticated', function (req: express.Request, res: express.Response, next: express.NextFunction) {
+  res.json('authentication is valid');
 });
 
 declare namespace jwtTypeExtension {

--- a/server/spec/authentication_spec.ts
+++ b/server/spec/authentication_spec.ts
@@ -3,7 +3,7 @@
 import {logger} from '../utils/logger';
 import {RequestResponse} from 'request';
 import {BASE_URL} from './constants';
-import {loginHeader, authBearerOptions} from './httpOptions';
+import {loginOptions, authBearerOptions} from './httpOptions';
 
 let request = require('request');
 let adminToken: string;
@@ -14,7 +14,7 @@ describe('Initial Authentication Test', function () {
     it('returns status code 401 -  wrong password', function (done) {
       let username: string = 'admin';
       request.post(TEST_URL,
-        loginHeader(username, 'xxxxxx'),
+        loginOptions(username, 'xxxxxx'),
         function (error: any, response: RequestResponse, body: any) {
           expect(response.statusCode).toBe(401);
           expect(body).toContain(`user ${username} wrong password`);
@@ -24,7 +24,7 @@ describe('Initial Authentication Test', function () {
     it('returns status code 401 -  wrong password', function (done) {
       let username: string = 'muster';
       request.post(TEST_URL,
-        loginHeader(username, 'xxxxxx'),
+        loginOptions(username, 'xxxxxx'),
         function (error: any, response: RequestResponse, body: any) {
           expect(response.statusCode).toBe(401);
           expect(body).toContain(`user ${username} unknown`);
@@ -34,7 +34,7 @@ describe('Initial Authentication Test', function () {
   });
   it('returns status code 200 - successfull authentication', function (done) {
     request.post(TEST_URL,
-      loginHeader('admin', '123456'),
+      loginOptions('admin', '123456'),
       function (error: any, response: RequestResponse, body: any) {
         expect(response.statusCode).toBe(200);
         let authData = JSON.parse(body);

--- a/server/spec/httpOptions.ts
+++ b/server/spec/httpOptions.ts
@@ -1,24 +1,24 @@
 import {CoreOptions} from '@types/request';
 
-export function loginHeader(username: string, password: string): CoreOptions {
-  let httpHeader: CoreOptions = {
-    form: {username: username, password: password},
+export function loginOptions(username: string, password: string): CoreOptions {
+  let options: CoreOptions = {
     headers: {
       'Content-Type': 'application/json'
-    }
+    },
+    form: {username: username, password: password}
   };
-  return httpHeader;
+  return options;
 }
 
 export function authBearerOptions(token: string, body?: any): CoreOptions {
-  let httpHeader: CoreOptions = {
+  let options: CoreOptions = {
     headers: {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json'
     }
   };
   if (body) {
-    httpHeader.body = body;
+    options.body = body;
   }
-  return httpHeader;
+  return options;
 }

--- a/server/spec/httpOptions.ts
+++ b/server/spec/httpOptions.ts
@@ -1,0 +1,24 @@
+import {CoreOptions} from '@types/request';
+
+export function loginHeader(username: string, password: string): CoreOptions {
+  let httpHeader: CoreOptions = {
+    form: {username: username, password: password},
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  };
+  return httpHeader;
+}
+
+export function authBearerOptions(token: string, body?: any): CoreOptions {
+  let httpHeader: CoreOptions = {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    }
+  };
+  if (body) {
+    httpHeader.body = body;
+  }
+  return httpHeader;
+}

--- a/server/spec/user_spec.ts
+++ b/server/spec/user_spec.ts
@@ -5,6 +5,8 @@ import {RequestResponse} from 'request';
 import {BASE_URL} from './constants';
 import {IUser} from '../entities/user.interface';
 import {UserType} from '../entities/user-type';
+import {loginHeader, authBearerOptions} from './httpOptions';
+
 
 describe('User Test', function () {
   const LOGIN_URL = BASE_URL + 'api/authenticate';
@@ -16,43 +18,36 @@ describe('User Test', function () {
   let testUserId: any;
 
   describe('GET ' + TEST_URL, function () {
-    it('returns status code 401 - not yet authenticated', function (done) {
-      request.get(TEST_URL, {
-        headers: {
-          'Authorization': '',
-          'Content-Type': 'application/json'
-        }
-      }, function (error: any, response: RequestResponse, body: any) {
-        expect(response.statusCode).toBe(401);
-        expect(body).toContain('not yet authenticated');
-        done();
-      });
+    it('returns status code 500 - not yet authenticated', function (done) {
+      request.get(TEST_URL,
+        authBearerOptions(''),
+        function (error: any, response: RequestResponse, body: any) {
+          expect(response.statusCode).toBe(500);
+          expect(body).toContain('No authorization token was found');
+          done();
+        });
     });
     it('returns status code 200 - successfull authentication', function (done) {
-      request.post(LOGIN_URL, {
-        'content-type': 'application/json',
-        form: {username: 'admin', password: '123456'}
-      }, function (error: any, response: RequestResponse, body: any) {
-        expect(response.statusCode).toBe(200);
-        let authData = JSON.parse(body);
-        adminToken = authData.token;
-        logger.debug(`admin-token: ${adminToken}`);
-        done();
-      });
+      request.post(LOGIN_URL,
+        loginHeader('admin', '123456'),
+        function (error: any, response: RequestResponse, body: any) {
+          expect(response.statusCode).toBe(200);
+          let authData = JSON.parse(body);
+          adminToken = authData.token;
+          logger.debug(`admin-token: ${adminToken}`);
+          done();
+        });
     });
     it('returns status code 200 - found some users', function (done) {
-      request.get(TEST_URL, {
-        headers: {
-          'Authorization': adminToken,
-          'Content-Type': 'application/json'
-        }
-      }, function (error: any, response: RequestResponse, body: any) {
-        expect(response.statusCode).toBe(200);
-        let users: IUser[] = JSON.parse(body).data;
-        logger.debug(`Users: ${users}`);
-        expect(users.length).toBeGreaterThan(0);
-        done();
-      });
+      request.get(TEST_URL,
+        authBearerOptions(adminToken),
+        function (error: any, response: RequestResponse, body: any) {
+          expect(response.statusCode).toBe(200);
+          let users: IUser[] = JSON.parse(body).data;
+          logger.debug(`Users: ${users}`);
+          expect(users.length).toBeGreaterThan(0);
+          done();
+        });
     });
   });
 
@@ -65,51 +60,40 @@ describe('User Test', function () {
       password: '1234'
     };
     it('returns status code 201 - user created', function (done) {
-      request.post(TEST_URL, {
-        headers: {
-          'Authorization': adminToken,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(testUser)
-      }, function (error: any, response: RequestResponse, body: any) {
-        logger.debug(`User created (body): ${body}`);
-        expect(response.statusCode).toBe(201);
-        logger.debug(`User created (body): ${body}`);
-        let user: IUser = JSON.parse(body).data;
-        logger.debug(`User created: ${JSON.stringify(user)}`);
-        testUserId = user.id;
-        logger.debug(`testUserId: ${testUserId}`);
-        done();
-      });
+      request.post(TEST_URL,
+        authBearerOptions(adminToken, JSON.stringify(testUser)),
+        function (error: any, response: RequestResponse, body: any) {
+          logger.debug(`User created (body): ${body}`);
+          expect(response.statusCode).toBe(201);
+          logger.debug(`User created (body): ${body}`);
+          let user: IUser = JSON.parse(body).data;
+          logger.debug(`User created: ${JSON.stringify(user)}`);
+          testUserId = user.id;
+          logger.debug(`testUserId: ${testUserId}`);
+          done();
+        });
     });
     it('returns status code 500 - user already exists', function (done) {
-      request.post(TEST_URL, {
-        headers: {
-          'Authorization': adminToken,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(testUser)
-      }, function (error: any, response: RequestResponse, body: any) {
-        expect(response.statusCode).toBe(500);
-        done();
-      });
+      request.post(TEST_URL,
+        authBearerOptions(adminToken, JSON.stringify(testUser)),
+        function (error: any, response: RequestResponse, body: any) {
+          expect(response.statusCode).toBe(500);
+          done();
+        });
     });
   });
 
   describe('GET ' + TEST_URL + '/' + testUserId, function () {
     it('returns status code 200 - found user', function (done) {
-      request.get(TEST_URL + '/' + testUserId, {
-        headers: {
-          'Authorization': adminToken,
-          'Content-Type': 'application/json'
-        }
-      }, function (error: any, response: RequestResponse, body: any) {
-        expect(response.statusCode).toBe(200);
-        let user: IUser = JSON.parse(body).data;
-        logger.debug(`User retrieved: ${JSON.stringify(user)}`);
-        expect(user.username).toBe(TEST_USERNAME);
-        done();
-      });
+      request.get(TEST_URL + '/' + testUserId,
+        authBearerOptions(adminToken),
+        function (error: any, response: RequestResponse, body: any) {
+          expect(response.statusCode).toBe(200);
+          let user: IUser = JSON.parse(body).data;
+          logger.debug(`User retrieved: ${JSON.stringify(user)}`);
+          expect(user.username).toBe(TEST_USERNAME);
+          done();
+        });
     });
   });
 
@@ -124,34 +108,27 @@ describe('User Test', function () {
       password: '1234'
     };
     it('returns status code 200 - user updated', function (done) {
-      request.put(TEST_URL + '/' + testUserId, {
-        headers: {
-          'Authorization': adminToken,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(testUser)
-      }, function (error: any, response: RequestResponse, body: any) {
-        expect(response.statusCode).toBe(200);
-        let user: IUser = JSON.parse(body).data;
-        logger.debug(`User updated: ${JSON.stringify(user)}`);
-        expect(user.lastname).toBe(LASTNAME);
-        done();
-      });
+      request.put(TEST_URL + '/' + testUserId,
+        authBearerOptions(adminToken, JSON.stringify(testUser)),
+        function (error: any, response: RequestResponse, body: any) {
+          expect(response.statusCode).toBe(200);
+          let user: IUser = JSON.parse(body).data;
+          logger.debug(`User updated: ${JSON.stringify(user)}`);
+          expect(user.lastname).toBe(LASTNAME);
+          done();
+        });
     });
   });
 
   describe('DELETE ' + TEST_URL + '/' + testUserId, function () {
     it('returns status code 200 - user deleted', function (done) {
-      request.delete(TEST_URL + '/' + testUserId, {
-        headers: {
-          'Authorization': adminToken,
-          'Content-Type': 'application/json'
-        }
-      }, function (error: any, response: RequestResponse, body: any) {
-        expect(response.statusCode).toBe(200);
-        testUserId = null;
-        done();
-      });
+      request.delete(TEST_URL + '/' + testUserId,
+        authBearerOptions(adminToken),
+        function (error: any, response: RequestResponse, body: any) {
+          expect(response.statusCode).toBe(200);
+          testUserId = null;
+          done();
+        });
     });
   });
 

--- a/server/spec/user_spec.ts
+++ b/server/spec/user_spec.ts
@@ -5,7 +5,7 @@ import {RequestResponse} from 'request';
 import {BASE_URL} from './constants';
 import {IUser} from '../entities/user.interface';
 import {UserType} from '../entities/user-type';
-import {loginHeader, authBearerOptions} from './httpOptions';
+import {loginOptions, authBearerOptions} from './httpOptions';
 
 
 describe('User Test', function () {
@@ -29,7 +29,7 @@ describe('User Test', function () {
     });
     it('returns status code 200 - successfull authentication', function (done) {
       request.post(LOGIN_URL,
-        loginHeader('admin', '123456'),
+        loginOptions('admin', '123456'),
         function (error: any, response: RequestResponse, body: any) {
           expect(response.statusCode).toBe(200);
           let authData = JSON.parse(body);


### PR DESCRIPTION
- Kleine Anpassung in authentication.ts: type statt userType, da es  in authenticationRoute.use('/api', eJwt({secret: 'secret'}), function (req: express.Request & jwtTypeExtension.Authenticated<IUserModel> auf IUserModel mappen muss.

- REST Tests sind ebenfalls angepasst. Entweder app.js in einem Terminal starten und jasmine in einem anderen oder beides zusammen in einem Termin mit gulp test starten. 