### PR TITLE
security issue: remove different handling for unknown user and wrong passwd

### DIFF
--- a/server/routes/authentication.ts
+++ b/server/routes/authentication.ts
@@ -33,10 +33,8 @@ authenticationRoute.post('/api/authenticate', function (req: express.Request, re
         res.json({
           token: authToken
         });
-      } else if (users.length == 0) {
-        res.status(401).json({error: `user ${username} unknown`});
       } else {
-        res.status(401).json({error: `user ${username} wrong password`});
+        res.status(401).json({error: `Incorrect username or password.`});
       }
     }
   });

--- a/server/spec/authentication_spec.ts
+++ b/server/spec/authentication_spec.ts
@@ -11,23 +11,13 @@ let adminToken: string;
 describe('Initial Authentication Test', function () {
   const TEST_URL = BASE_URL + 'api/authenticate';
   describe('POST ' + TEST_URL, function () {
-    it('returns status code 401 -  wrong password', function (done) {
+    it('returns status code 401 -  wrong username or password', function (done) {
       let username: string = 'admin';
       request.post(TEST_URL,
         loginOptions(username, 'xxxxxx'),
         function (error: any, response: RequestResponse, body: any) {
           expect(response.statusCode).toBe(401);
-          expect(body).toContain(`user ${username} wrong password`);
-          done();
-        });
-    });
-    it('returns status code 401 -  wrong password', function (done) {
-      let username: string = 'muster';
-      request.post(TEST_URL,
-        loginOptions(username, 'xxxxxx'),
-        function (error: any, response: RequestResponse, body: any) {
-          expect(response.statusCode).toBe(401);
-          expect(body).toContain(`user ${username} unknown`);
+          expect(body).toContain(`Incorrect username or password.`);
           done();
         });
     });


### PR DESCRIPTION
Wir dürfen einem User nicht mitteilen, ob sein Passwort oder sein Username falsch ist. Tun wir dies, ist ein Angriff auf das Login deutlich einfacher. Sonst kann ich einfach herausfinden, ob ein User gültig ist oder nicht.
Z.B. bei github immer die gleiche Meldung zurück gegeben. 