### PR TITLE
use hashed passwords in db

### DIFF
--- a/server/models/user.model.ts
+++ b/server/models/user.model.ts
@@ -2,6 +2,7 @@ import {Logger, getLogger} from '../utils/logger';
 import {Document, Schema, Model, model} from 'mongoose';
 import {IUser} from '../entities/user.interface';
 import {UserType} from '../entities/user-type';
+import {hash, compare} from 'bcrypt';
 
 const LOGGER: Logger = getLogger('UserModel');
 
@@ -19,12 +20,20 @@ let UserSchema = new Schema({
   versionKey: false, // avoids __v, i.e. the version key
 });
 
-/*
- UserSchema.pre('save', (next) => {
- // TODO: Pre save validation
- next();
- });
- */
+UserSchema.pre(`save`, function (next) {
+  let user: IUserDocument = this;
+
+// only hash the password if it has been modified (or is new)
+  if (!user.isModified('password')) return next();
+
+  hash(user.password, 8, function (err, hash) {
+    if (err) return next(err);
+
+    // override the cleartext password with the hashed one
+    user.password = hash;
+    next();
+  });
+});
 
 export const UserModel: Model<IUserDocument> = model<IUserDocument>('User', UserSchema);
 

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/bcrypt": "^1.0.0",
     "@types/body-parser": "0.0.33",
     "@types/compression": "0.0.33",
     "@types/express": "^4.0.34",
@@ -28,6 +29,7 @@
     "@types/request": "0.0.39",
     "@types/socket.io": "^1.4.27",
     "@types/uuid": "^2.0.29",
+    "bcrypt": "^1.0.2",
     "body-parser": "^1.15.2",
     "command-line-args": "^4.0.1",
     "compression": "^1.6.2",


### PR DESCRIPTION
Hallo Stephan,

ich habe das verschlüsselte Passwort Feature heute morgen im Zug für mein Miniprojekt implementiert und jetzt in diesen Branch "gecherry-pcked". Du musst danach auf dem server ein "npm install" ausführen.

Mit dem Update, kannst du dich nicht mehr anmelden (plaintext passwort in DB anstelle von passwort hash). Es gibt zwei Varianten um das Problem zu lösen:
1. Datenbank löschen
2. Sicherstellen, dass der Client ein gültiges Token hat, Server updaten und neustarten, im Client das eigene Passwort mit einem neuen ersetzten. Es darf nicht gleich sein wie das alte, sonst wird der Hash nicht berechnet. Wenn du aber wieder das alte haben möchtest, dann kannst du es zweimal ändern. 

Gruss